### PR TITLE
put artifact in s3 without attempting to include AuthenticatedRead ACL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ crossSbtVersions := List("0.13.18", "1.2.8")
 
 releaseCrossBuild := true
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+//releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 // Testing
 libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.6" % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+//addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+//
+//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,41 +1,44 @@
+//
+//publishMavenStyle := true
+//
+//publishTo := sonatypePublishTo.value
+//
+//publishArtifact in Test := false
+//
+//pomIncludeRepository := { _ => false }
+//
+//sonatypeProfileName := "com.gilt"
+//
+//pomExtra := {
+//  <url>https://github.com/gilt/sbt-aws-lambda</url>
+//  <scm>
+//    <url>git@github.com:gilt/sbt-aws-lambda.git</url>
+//    <connection>scm:git:git@github.com:gilt/sbt-aws-lambda.git</connection>
+//  </scm>
+//  <licenses>
+//    <license>
+//      <name>Apache 2</name>
+//      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+//    </license>
+//  </licenses>
+//  <developers>
+//    <developer>
+//      <id>bstjohn</id>
+//      <name>Brendan St John</name>
+//      <url>https://github.com/stjohnb</url>
+//    </developer>
+//    <developer>
+//      <id>fiadliel</id>
+//      <name>Gary Coady</name>
+//      <url>https://github.com/fiadliel</url>
+//    </developer>
+//    <developer>
+//      <id>sullis</id>
+//      <name>Sean Sullivan</name>
+//      <url>https://github.com/sullis</url>
+//    </developer>
+//  </developers>
+//}
 
-publishMavenStyle := true
-
-publishTo := sonatypePublishTo.value
-
-publishArtifact in Test := false
-
-pomIncludeRepository := { _ => false }
-
-sonatypeProfileName := "com.gilt"
-
-pomExtra := {
-  <url>https://github.com/gilt/sbt-aws-lambda</url>
-  <scm>
-    <url>git@github.com:gilt/sbt-aws-lambda.git</url>
-    <connection>scm:git:git@github.com:gilt/sbt-aws-lambda.git</connection>
-  </scm>
-  <licenses>
-    <license>
-      <name>Apache 2</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-  <developers>
-    <developer>
-      <id>bstjohn</id>
-      <name>Brendan St John</name>
-      <url>https://github.com/stjohnb</url>
-    </developer>
-    <developer>
-      <id>fiadliel</id>
-      <name>Gary Coady</name>
-      <url>https://github.com/fiadliel</url>
-    </developer>
-    <developer>
-      <id>sullis</id>
-      <name>Sean Sullivan</name>
-      <url>https://github.com/sullis</url>
-    </developer>
-  </developers>
-}
+// for publishing to jfrog artifactory
+publishMavenStyle := false

--- a/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
@@ -9,7 +9,7 @@ private[lambda] class AwsS3(client: wrapper.AmazonS3) {
   def pushJarToS3(jar: File, bucketId: S3BucketId, s3KeyPrefix: String): Try[S3Key] = {
     val key = s3KeyPrefix + jar.getName
     val objectRequest = new PutObjectRequest(bucketId.value, key, jar)
-      .withCannedAcl(CannedAccessControlList.AuthenticatedRead)
+      // .withCannedAcl(CannedAccessControlList.AuthenticatedRead)
 
     client.putObject(objectRequest)
       .map { _ => S3Key(key) }


### PR DESCRIPTION
This is motivated by the fact that uploading objects with ACLs requires one to disable a recommended setting: "Block new public ACLs and uploading public objects" in S3 console.

> Prevents setting or updating public bucket or object ACLs. if you try to put public ACLs on a bucket or object or upload objects with public ACLs, the request is rejected with an access denied error. This setting doesn’t affect your existing public ACLs. Use this setting to ensure that no one can put public ACLs on a bucket or object in the future, and disallow any objects with public ACLs from being uploaded.